### PR TITLE
Added manual pages

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -4,6 +4,7 @@
       <w>autoremove</w>
       <w>libmodpm</w>
       <w>modpm</w>
+      <w>reinstalls</w>
       <w>versionlock</w>
     </words>
   </dictionary>

--- a/man/index.txt
+++ b/man/index.txt
@@ -1,0 +1,12 @@
+modpm-autoremove(1)     modpm-autoremove.1
+modpm-history(1)        modpm-history.1
+modpm-info(1)           modpm-info.1
+modpm-init(1)           modpm-init.1
+modpm-install(1)        modpm-install.1
+modpm-list(1)           modpm-list.1
+modpm-mark(1)           modpm-mark.1
+modpm-reinstall(1)      modpm-reinstall.1
+modpm-remove(1)         modpm-remove.1
+modpm-search(1)         modpm-search.1
+modpm-upgrade(1)        modpm-upgrade.1
+modpm-versionlock(1)    modpm-versionlock.1

--- a/man/index.txt
+++ b/man/index.txt
@@ -1,3 +1,4 @@
+modpm(1)                modpm.1
 modpm-autoremove(1)     modpm-autoremove.1
 modpm-history(1)        modpm-history.1
 modpm-info(1)           modpm-info.1

--- a/man/modpm-autoremove.1.md
+++ b/man/modpm-autoremove.1.md
@@ -1,0 +1,23 @@
+# modpm-autoremove(1) -- Autoremove Command
+
+## SYNOPSIS
+
+modpm autoremove \[options]
+
+## DESCRIPTION
+
+The `autoremove` command removes packages that were installed as dependencies but are no longer needed.
+
+## OPTIONS
+
+`-y`, `--assumeyes`
+:   Automatically answer yes to all prompts.
+
+## SEE ALSO
+
+modpm-mark(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-history.1.md
+++ b/man/modpm-history.1.md
@@ -1,0 +1,40 @@
+# modpm-history(1) -- History Command
+
+## SYNOPSIS
+
+modpm history \<subcommand> \[options] \[\<transaction-id>]
+
+## DESCRIPTION
+
+The `history` command displays the transaction history of modpm, allowing users to review past operations, restore the
+system to a previous state, or retry incomplete transactions.
+
+## SUBCOMMANDS
+
+`list`
+:   List recorded transactions.
+
+`info`
+:   Display details about a specific transaction.
+
+`redo`
+:   Repeat the specified transaction.
+
+`revert`
+:   Revert the specified and all subsequent transactions.
+
+## OPTIONS FOR LIST
+
+`--reverse`
+:   List transactions in reverse chronological order.
+
+`--contains-pkgs=PACKAGE_NAME,...`
+:   Show only transactions containing the specified package names.
+
+`-n`, `--limit=COUNT`
+:   Limit the number of transactions displayed.
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-info.1.md
+++ b/man/modpm-info.1.md
@@ -1,0 +1,27 @@
+# modpm-info(1) -- Info Command
+
+## SYNOPSIS
+
+modpm info \[options] \[\<package\[:version\]>]
+
+## DESCRIPTION
+
+The `info` command displays detailed information about an installed package managed by modpm in the active scope, or
+available packages on Modrinth.
+
+A specific version may be selected using a colon (:) delimiter. If no version is specified, information about any
+installed version and the latest available version is shown.
+
+## OPTIONS
+
+`--all-deps`
+:   Lists all required dependencies, both direct and transitive.
+
+## SEE ALSO
+
+modpm-search(1), modpm-list(1), modpm-install(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-init.1.md
+++ b/man/modpm-init.1.md
@@ -1,0 +1,22 @@
+# modpm-init(1) -- Init Command
+
+## SYNOPSIS
+
+modpm init \[options]
+
+## DESCRIPTION
+
+The `init` command interactively initialises a new modpm scope in the current directory, setting up the necessary
+metadata and configuration for package management within the scope.
+
+It attempts to detect packages already present in the scope. Packages unavailable on Modrinth are reported with a
+warning, while recognised packages may be imported into the manifest for modpm to manage.
+
+## SEE ALSO
+
+modpm(1), modpm-mark(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-install.1.md
+++ b/man/modpm-install.1.md
@@ -15,6 +15,9 @@ compatible version is selected.
 
 ## OPTIONS
 
+`--ignore-installed`
+:   Ignore packages that are already installed.
+
 `--skip-broken`
 :   Allow skipping packages that cannot be installed due to dependency conflicts.
 

--- a/man/modpm-install.1.md
+++ b/man/modpm-install.1.md
@@ -8,7 +8,7 @@ modpm install \[options] \<package\[:version\]>...
 
 The `install` command installs one or more Modrinth projects as packages. modpm resolves and installs all required
 dependencies unless the target package is already installed. In that case, no dependency resolution is performed, and
-modpm only verifies that the package is present.
+modpm only verifies that the package is present. Only one version of each package may be installed at any given time.
 
 Each package may optionally specify a version using a colon (:) delimiter. If no version is specified, the latest
 compatible version is selected.

--- a/man/modpm-install.1.md
+++ b/man/modpm-install.1.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-modpm install \[options] \<package\[:version\]>...
+modpm install \[options] \<package\[:version]>...
 
 ## DESCRIPTION
 

--- a/man/modpm-install.1.md
+++ b/man/modpm-install.1.md
@@ -1,0 +1,42 @@
+# modpm-install(1) -- Install Command
+
+## SYNOPSIS
+
+modpm install \[options] \<package\[:version\]>...
+
+## DESCRIPTION
+
+The `install` command installs one or more Modrinth projects as packages. modpm resolves and installs all required
+dependencies unless the target package is already installed. In that case, no dependency resolution is performed, and
+modpm only verifies that the package is present.
+
+Each package may optionally specify a version using a colon (:) delimiter. If no version is specified, the latest
+compatible version is selected.
+
+## OPTIONS
+
+`--skip-broken`
+:   Allow skipping packages that cannot be installed due to dependency conflicts.
+
+`--skip-unavailable`
+:   Allow skipping packages that cannot be found on Modrinth.
+
+`-y`, `--assumeyes`
+:   Automatically answer yes to all prompts.
+
+## EXAMPLES
+
+`modpm install foo bar`
+:   Install the latest versions of `foo` and `bar`.
+
+`modpm install foo:1.2.3 bar`
+:   Install the defined version for `foo` and the latest version for `bar`.
+
+# SEE ALSO
+
+modpm-reinstall(1), modpm-upgrade(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-list.1.md
+++ b/man/modpm-list.1.md
@@ -1,0 +1,35 @@
+# modpm-list(1) -- List Command
+
+## SYNOPSIS
+
+modpm list \[options]
+
+## DESCRIPTION
+
+The `list` command displays all packages currently installed.
+
+## OPTIONS
+
+`--user`
+:   Show only packages that were explicitly installed by the user.
+
+`--dependencies`
+:   Show only packages that were installed as dependencies.
+
+`--deps-of=PACKAGE_NAME,...`
+:   Show only packages that are dependencies of the specified packages.
+
+`--rdeps-of=PACKAGE_NAME,...`
+:   Show only packages that depend on the specified packages.
+
+`--autoremove`
+:   Show only packages that will be removed by the <u>autoremove</u> command.
+
+## SEE ALSO
+
+modpm-info(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-mark.1.md
+++ b/man/modpm-mark.1.md
@@ -1,0 +1,27 @@
+# modpm-mark(1) -- Mark Command
+
+## SYNOPSIS
+
+modpm mark \<subcommand> \[options] \<package>...
+
+## DESCRIPTION
+
+The `mark` command changes the installation reason for one or more installed packages.
+
+## SUBCOMMANDS
+
+`user`
+:   Mark the specified packages as explicitly installed by the user.
+
+`dependency`
+:   Mark the specified packages as installed as dependencies.
+
+## OPTIONS
+
+`--skip-unavailable`
+:   Allow skipping packages that are not installed.
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-reinstall.1.md
+++ b/man/modpm-reinstall.1.md
@@ -1,0 +1,29 @@
+# modpm-reinstall(1) -- Reinstall Command
+
+## SYNOPSIS
+
+modpm reinstall \[options] \[\<package>...]
+
+## DESCRIPTION
+
+The `reinstall` command reinstalls packages in the active scope.
+
+When one or more packages are specified, only those packages are checked and reinstalled if necessary.
+
+When no packages are specified, all installed packages are checked and reinstalled if needed. The command may also
+suggest removal of packages found on disk that are not recorded in the manifest. Packages not available on Modrinth are
+always ignored.
+
+## OPTIONS
+
+`--no-remove`
+:   Skip removing Modrinth packages found on disk that are not recorded in the manifest.
+
+## SEE ALSO
+
+modpm-list(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-remove.1.md
+++ b/man/modpm-remove.1.md
@@ -1,0 +1,23 @@
+# modpm-remove(1) -- Remove Command
+
+## SYNOPSIS
+
+modpm remove \[options] \<package>...
+
+## DESCRIPTION
+
+The `remove` command uninstalls one or more packages from the active scope.
+
+## OPTIONS
+
+`--no-autoremove`
+:   Disable removal of dependencies that are no longer used.
+
+## SEE ALSO
+
+modpm-autoremove(1), modpm-mark(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-search.1.md
+++ b/man/modpm-search.1.md
@@ -1,0 +1,52 @@
+# modpm-search(1) -- Search Command
+
+## SYNOPSIS
+
+modpm search \[options] \[\<query>...]
+
+modpm search --list-categories
+
+## DESCRIPTION
+
+The `search` command queries available packages on Modrinth. When no query is provided, all packages matching any
+filters are returned.
+
+When `--list-categories` is specified, the command displays the full list of available categories instead of performing
+a search.
+
+## OPTIONS
+
+`-c`, `--category=NAME,...`
+:   Show only packages that are tagged with all the specified categories.
+
+`-n`, `--not-category=NAME,...`
+:   Exclude packages that have tagged with any of the specified categories.
+
+`--sort=<relevance|downloads|follows|newest|updated>`
+:    Sort results by relevance (default), downloads, follows, newest published, or most recently updated.
+
+`--limit=COUNT`
+:    Limit the number of search results displayed (default: 20).
+
+`--page=PAGE`
+:    Show the specified page of search results (1-based index).
+
+## EXAMPLES
+
+`modpm search -c=economy -n=game-mechanics bank`
+:   Search for packages matching `bank` tagged with `economy` but excluding those tagged with `game-mechanics`.
+
+`modpm search -c social voice chat`
+:   Search for packages matching `voice chat` tagged with `social`.
+
+`modpm search --list-categories`
+:   List all available categories.
+
+## SEE ALSO
+
+modpm-info(1), modpm-install(1), modpm-list(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-search.1.md
+++ b/man/modpm-search.1.md
@@ -22,6 +22,9 @@ a search.
 `-n`, `--not-category=NAME,...`
 :   Exclude packages that have tagged with any of the specified categories.
 
+`-o`, `--open-source`
+:   Show only packages published under an open source licence.
+
 `--sort=<relevance|downloads|follows|newest|updated>`
 :    Sort results by relevance (default), downloads, follows, newest published, or most recently updated.
 
@@ -33,8 +36,9 @@ a search.
 
 ## EXAMPLES
 
-`modpm search -c=economy -n=game-mechanics bank`
-:   Search for packages matching `bank` tagged with `economy` but excluding those tagged with `game-mechanics`.
+`modpm search -c=economy -n=game-mechanics -o bank`
+:   Search for open source packages matching `bank` tagged with `economy` but excluding those tagged with
+`game-mechanics`.
 
 `modpm search -c social voice chat`
 :   Search for packages matching `voice chat` tagged with `social`.

--- a/man/modpm-upgrade.1.md
+++ b/man/modpm-upgrade.1.md
@@ -1,0 +1,33 @@
+# modpm-upgrade(1) -- Upgrade Command
+
+## SYNOPSIS
+
+modpm upgrade \[options] \[\<package>...]
+
+## DESCRIPTION
+
+The `upgrade` command updates installed packages to their latest compatible versions by querying the Modrinth registry
+for available updates.
+
+When no packages are specified, the command attempts to upgrade all installed packages to their latest compatible
+versions. If one or more package names are provided, only those packages are considered for upgrade.
+
+## OPTIONS
+
+`--skip-broken`
+:   Allow skipping packages that cannot be upgraded due to dependency conflicts.
+
+`--skip-unavailable`
+:   Allow skipping packages that cannot be found on Modrinth.
+
+`-y`, `--assumeyes`
+:   Automatically answer yes to all prompts.
+
+## SEE ALSO
+
+modpm-list(1), modpm-install(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm-versionlock.1.md
+++ b/man/modpm-versionlock.1.md
@@ -1,0 +1,28 @@
+# modpm-versionlock(1) -- Version Lock Command
+
+## SYNOPSIS
+
+modpm versionlock \<subcommand> \[\<package>...]
+
+## DESCRIPTION
+
+The `versionlock` command manages package version locks, preventing any change to the installed version of a package.
+
+## SUBCOMMANDS
+
+`add`
+:   Lock one or more installed packages to their current versions.
+
+`clear`
+:   Clear all package version locks.
+
+`delete`
+:   Remove the version lock from one or more specified packages.
+
+`list`
+:   List all installed packages with version locks.
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm.1.md
+++ b/man/modpm.1.md
@@ -104,4 +104,4 @@ modpm-autoremove(1), modpm-history(1), modpm-info(1), modpm-init(1), modpm-insta
 ## COPYRIGHT
 
 Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
-See **https://github.com/modpm/lib/blob/main/COPYING** for the full licence text.
+See <https://github.com/modpm/cli/blob/main/COPYING> for the full licence text.

--- a/man/modpm.1.md
+++ b/man/modpm.1.md
@@ -1,0 +1,107 @@
+# modpm(1) -- Modrinth Package Manager
+
+## SYNOPSIS
+
+modpm \<command> \[options] \[\<args...>]
+
+## DESCRIPTION
+
+`modpm` is a command-line package manager for Modrinth projects. It allows users to install, upgrade, and remove
+Modrinth projects as packages. `modpm` supports managing any project type available on Modrinth, providing standard
+package management functionalities tailored to Modrinth’s ecosystem.
+
+## COMMANDS
+
+Here is a list of the available commands. For detailed information on each command’s usage and options, see the
+respective manual pages, for example, `man modpm install`.
+
+`autoremove`
+:   Remove unneeded packages.
+
+`history`
+:   Manage transaction history.
+
+`info`
+:   Provide detailed information about installed or available packages.
+
+`init`
+:   Initialise a directory to manage.
+
+`install`
+:   Install packages.
+
+`list`
+:   List installed packages.
+
+`mark`
+:   Change the reason for a package to be installed.
+
+`reinstall`
+:   Reinstall packages.
+
+`remove`
+:   Remove packages.
+
+`search`
+:   Search for packages using keywords.
+
+`upgrade`
+:   Upgrade packages.
+
+`versionlock`
+:   Protect packages from being changed.
+
+## OPTIONS
+
+The following options are available for all `modpm` commands:
+
+`-h`, `--help`
+:   Show the help.
+
+`-v`, `--version`
+:   Show the version of the modpm CLI and libmodpm library.
+
+## EXIT STATUS
+
+The `modpm` command exits with the following exit codes:
+
+`0`
+:   Operation succeeded.
+
+`1`
+:   An error occurred during the operation.
+
+`2`
+:   An error occurred during processing of arguments.
+
+`3`
+:   A network error occurred.
+
+`130`
+:   Operation cancelled by user.
+
+## FILES
+
+`.modpm/`
+:   Directory created by `modpm init` to mark the scope of package management.
+
+`.modpm/bak/`
+:   Backup directory where packages pending removal are temporarily stored.
+
+`.modpm/config.json`
+:   Configuration file created during initialisation. Can be edited to change settings.
+
+`.modpm/history.json`
+:   Transaction history log. Modifying manually is not advised.
+
+`.modpm/manifest.json`
+:   Manifest of the installed packages. Modifying manually is not advised.
+
+## SEE ALSO
+
+modpm-autoremove(1), modpm-history(1), modpm-info(1), modpm-init(1), modpm-install(1), modpm-list(1), modpm-mark(1), modpm-reinstall(1), modpm-remove(1), modpm-search(1), modpm-upgrade(1), modpm-versionlock(1)
+
+## COPYRIGHT
+
+Copyright 2025 Zefir Kirilov. modpm is available under the GPL-3.0 licence.
+See **https://github.com/modpm/lib/blob/main/COPYING** for the full licence text.


### PR DESCRIPTION
The manual pages are written in Markdown for simplicity. I am currently locally converting them to roff and html using [`ronn`](https://github.com/rtomayko/ronn/) with the following command:

```sh
ronn man/*.md --style=toc -o ronn --manual=modpm
```